### PR TITLE
feat: Tasks for Employees

### DIFF
--- a/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
+++ b/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
@@ -1,0 +1,67 @@
+package com.crud.serverside.controller;
+
+import com.crud.serverside.exception.ResourceNotFoundException;
+import com.crud.serverside.model.Task;
+import com.crud.serverside.repository.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@CrossOrigin(origins = "http://localhost:5173")
+@RestController
+@RequestMapping("/api/v1/")
+public class TaskController {
+    @Autowired
+    private TaskRepository taskRepository;
+
+    // Get All Tasks
+    @GetMapping("/tasks")
+    public List<Task> getAllTasks() {
+        return taskRepository.findAll();
+    }
+
+    // Create New Task
+    @PostMapping("/tasks")
+    public Task createTask(@RequestBody Task task) {
+        return taskRepository.save(task);
+    }
+
+    // Get Task by ID
+    @GetMapping("/tasks/{id}")
+    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + id));
+
+        return ResponseEntity.ok(task);
+    }
+
+    // Update Task by ID
+    @PutMapping("/tasks/{id}")
+    public ResponseEntity<Task> updateTask(@PathVariable Long id, @RequestBody Task taskDetails) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + id));
+
+        task.setTaskName(taskDetails.getTaskName());
+        task.setTaskDescription(task.getTaskDescription());
+        task.setAssignedEmployees(taskDetails.getAssignedEmployees());
+
+        Task updateTask = taskRepository.save(task);
+
+        return ResponseEntity.ok(updateTask);
+    }
+
+    // Delete Task by ID
+    @DeleteMapping("/tasks/{id}")
+    public Map<String, Boolean> deleteTask(@PathVariable Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + id));
+        taskRepository.delete(task);
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("Deleted", Boolean.TRUE);
+        return response;
+    }
+}

--- a/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
+++ b/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
@@ -1,7 +1,9 @@
 package com.crud.serverside.controller;
 
 import com.crud.serverside.exception.ResourceNotFoundException;
+import com.crud.serverside.model.Employee;
 import com.crud.serverside.model.Task;
+import com.crud.serverside.repository.EmployeeRepository;
 import com.crud.serverside.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,9 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/")
 public class TaskController {
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
     @Autowired
     private TaskRepository taskRepository;
 
@@ -62,6 +67,40 @@ public class TaskController {
         taskRepository.delete(task);
         Map<String, Boolean> response = new HashMap<>();
         response.put("Deleted", Boolean.TRUE);
+        return response;
+    }
+
+    // Add Employee to Task by ID
+    @PutMapping("/tasks/{taskId}/employees")
+    public Map<String, Boolean> assignEmployeeToTask(@PathVariable Long taskId, @RequestBody Map<String, Long> data) {
+        long employeeId = data.containsKey("employeeId") ? data.get("employeeId") : -1;
+
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + taskId));
+
+        Employee employee = employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
+
+        task.assignEmployee(employee);
+        taskRepository.save(task);
+
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("Assigned", Boolean.TRUE);
+        return response;
+    }
+
+    // Remove Employee from Task
+    @DeleteMapping("/tasks/{taskId}/employees/{employeeId}")
+    public Map<String, Boolean> removeEmployeeFromTask(@PathVariable Long taskId, @PathVariable Long employeeId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + taskId));
+
+        Employee employee = employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
+
+        task.removeEmployeeAssignment(employee);
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("Removed", Boolean.TRUE);
         return response;
     }
 }

--- a/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
+++ b/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
@@ -72,7 +72,7 @@ public class TaskController {
 
     // Add Employee to Task by ID
     @PutMapping("/tasks/{taskId}/employees")
-    public Map<String, Boolean> assignEmployeeToTask(@PathVariable Long taskId, @RequestBody Map<String, Long> data) {
+    public ResponseEntity<Task> assignEmployeeToTask(@PathVariable Long taskId, @RequestBody Map<String, Long> data) {
         long employeeId = data.containsKey("employeeId") ? data.get("employeeId") : -1;
 
         Task task = taskRepository.findById(taskId)
@@ -82,16 +82,16 @@ public class TaskController {
                 .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
 
         boolean assigned = task.assignEmployee(employee);
-        taskRepository.save(task);
-
-        Map<String, Boolean> response = new HashMap<>();
-        response.put("Assigned", assigned);
-        return response;
+        Task updatedTask = taskRepository.save(task);
+        if (assigned)
+            return ResponseEntity.ok(updatedTask);
+        else
+            return ResponseEntity.badRequest().body(updatedTask);
     }
 
     // Remove Employee from Task
     @DeleteMapping("/tasks/{taskId}/employees/{employeeId}")
-    public Map<String, Boolean> removeEmployeeFromTask(@PathVariable Long taskId, @PathVariable Long employeeId) {
+    public ResponseEntity<Task> removeEmployeeFromTask(@PathVariable Long taskId, @PathVariable Long employeeId) {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new ResourceNotFoundException("Task does not exist with id:" + taskId));
 
@@ -99,9 +99,10 @@ public class TaskController {
                 .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
 
         boolean removed = task.removeEmployeeAssignment(employee);
-        taskRepository.save(task);
-        Map<String, Boolean> response = new HashMap<>();
-        response.put("Removed", removed);
-        return response;
+        Task updatedTask = taskRepository.save(task);
+        if (removed)
+            return ResponseEntity.ok(updatedTask);
+        else
+            return ResponseEntity.badRequest().body(updatedTask);
     }
 }

--- a/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
+++ b/server-side/src/main/java/com/crud/serverside/controller/TaskController.java
@@ -81,11 +81,11 @@ public class TaskController {
         Employee employee = employeeRepository.findById(employeeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
 
-        task.assignEmployee(employee);
+        boolean assigned = task.assignEmployee(employee);
         taskRepository.save(task);
 
         Map<String, Boolean> response = new HashMap<>();
-        response.put("Assigned", Boolean.TRUE);
+        response.put("Assigned", assigned);
         return response;
     }
 
@@ -98,9 +98,10 @@ public class TaskController {
         Employee employee = employeeRepository.findById(employeeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Employee does not exist with id:" + employeeId));
 
-        task.removeEmployeeAssignment(employee);
+        boolean removed = task.removeEmployeeAssignment(employee);
+        taskRepository.save(task);
         Map<String, Boolean> response = new HashMap<>();
-        response.put("Removed", Boolean.TRUE);
+        response.put("Removed", removed);
         return response;
     }
 }

--- a/server-side/src/main/java/com/crud/serverside/model/Task.java
+++ b/server-side/src/main/java/com/crud/serverside/model/Task.java
@@ -3,6 +3,7 @@ package com.crud.serverside.model;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -34,6 +35,7 @@ public class Task {
         this.id = id;
         this.taskName = taskName;
         this.taskDescription = taskDescription;
+        this.assignedEmployees = new ArrayList<>();
     }
 
     public Task(long id, String taskName, String taskDescription, List<Employee> assignedEmployees) {
@@ -75,11 +77,11 @@ public class Task {
         this.assignedEmployees = assignedEmployees;
     }
 
-    public void assignEmployee(Employee employee){
-        this.assignedEmployees.add(employee);
+    public boolean assignEmployee(Employee employee){
+        return this.assignedEmployees.add(employee);
     }
 
-    public void removeEmployeeAssignment(Employee employee){
-        this.assignedEmployees.remove(employee);
+    public boolean removeEmployeeAssignment(Employee employee){
+        return this.assignedEmployees.remove(employee);
     }
 }

--- a/server-side/src/main/java/com/crud/serverside/model/Task.java
+++ b/server-side/src/main/java/com/crud/serverside/model/Task.java
@@ -78,10 +78,16 @@ public class Task {
     }
 
     public boolean assignEmployee(Employee employee){
+        if (assignedEmployees.stream().anyMatch(o -> o.getId() == employee.getId()))
+            return false;
+
         return this.assignedEmployees.add(employee);
     }
 
     public boolean removeEmployeeAssignment(Employee employee){
-        return this.assignedEmployees.remove(employee);
+        if (assignedEmployees.stream().anyMatch(o ->  o.getId() == employee.getId()))
+            return this.assignedEmployees.remove(employee);
+
+        return false;
     }
 }

--- a/server-side/src/main/java/com/crud/serverside/model/Task.java
+++ b/server-side/src/main/java/com/crud/serverside/model/Task.java
@@ -1,0 +1,85 @@
+package com.crud.serverside.model;
+
+
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "tasks")
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "task_name")
+    private String taskName;
+
+    @Column(name = "task_description")
+    private String taskDescription;
+
+    @ManyToMany
+    @JoinTable(
+            name = "employee_task",
+            joinColumns = {@JoinColumn(name = "task_id")},
+            inverseJoinColumns = {@JoinColumn(name = "employee_id")}
+    )
+    private List<Employee> assignedEmployees;
+
+    public Task(){
+
+    }
+
+    public Task(long id, String taskName, String taskDescription) {
+        this.id = id;
+        this.taskName = taskName;
+        this.taskDescription = taskDescription;
+    }
+
+    public Task(long id, String taskName, String taskDescription, List<Employee> assignedEmployees) {
+        this.id = id;
+        this.taskName = taskName;
+        this.taskDescription = taskDescription;
+        this.assignedEmployees = assignedEmployees;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public void setTaskName(String taskName) {
+        this.taskName = taskName;
+    }
+
+    public String getTaskDescription() {
+        return taskDescription;
+    }
+
+    public void setTaskDescription(String taskDescription) {
+        this.taskDescription = taskDescription;
+    }
+
+    public List<Employee> getAssignedEmployees() {
+        return assignedEmployees;
+    }
+
+    public void setAssignedEmployees(List<Employee> assignedEmployees) {
+        this.assignedEmployees = assignedEmployees;
+    }
+
+    public void assignEmployee(Employee employee){
+        this.assignedEmployees.add(employee);
+    }
+
+    public void removeEmployeeAssignment(Employee employee){
+        this.assignedEmployees.remove(employee);
+    }
+}

--- a/server-side/src/main/java/com/crud/serverside/repository/TaskRepository.java
+++ b/server-side/src/main/java/com/crud/serverside/repository/TaskRepository.java
@@ -1,0 +1,9 @@
+package com.crud.serverside.repository;
+
+import com.crud.serverside.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}


### PR DESCRIPTION
Added Tasks which can be assigned to Employees. Closes #3 

Created
- TaskModel
- TaskRepository
- TaskController

This will also create a `employee_task` table which will join Employees with Tasks with a Many to Many relationship

The controller has APIs defined for basic CRUD and also some extra definitions like "Assigning an Employee (based on their ID) to a specific Task (based on its ID)" and "Removing an Employee (based on their ID) from a particular Task (based on its ID)"